### PR TITLE
[WEB-69] feat(control): creating a component control

### DIFF
--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-disable.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-disable.svg
@@ -1,0 +1,13 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.25">
+<g clip-path="url(#clip0_472_1657)">
+<path d="M12.8431 10.3431L18.5 16L12.8431 21.6568" stroke="#30373F"/>
+</g>
+<rect x="0.5" y="0.5" width="31" height="31" rx="15.5" stroke="#30373F"/>
+</g>
+<defs>
+<clipPath id="clip0_472_1657">
+<rect width="16" height="16" fill="white" transform="translate(8 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-navy.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-navy.svg
@@ -1,0 +1,11 @@
+<svg width="33" height="32" viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_472_1615)">
+<path d="M13.3431 10.3431L19 16L13.3431 21.6568" stroke="#30373F"/>
+</g>
+<rect x="1" y="0.5" width="31" height="31" rx="15.5" stroke="#30373F"/>
+<defs>
+<clipPath id="clip0_472_1615">
+<rect width="16" height="16" fill="white" transform="translate(8.5 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-white.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-next-white.svg
@@ -1,0 +1,11 @@
+<svg width="33" height="32" viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_471_1480)">
+<path d="M13.3431 10.3431L19 16L13.3431 21.6568" stroke="white"/>
+</g>
+<rect x="1" y="0.5" width="31" height="31" rx="15.5" stroke="white"/>
+<defs>
+<clipPath id="clip0_471_1480">
+<rect width="16" height="16" fill="white" transform="translate(8.5 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-disable.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-disable.svg
@@ -1,0 +1,13 @@
+<svg width="33" height="32" viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.25">
+<g clip-path="url(#clip0_472_1614)">
+<path d="M19.1569 21.3137L13.5 15.6569L19.1569 10" stroke="#30373F"/>
+</g>
+<rect x="1" y="0.5" width="31" height="31" rx="15.5" stroke="#30373F"/>
+</g>
+<defs>
+<clipPath id="clip0_472_1614">
+<rect width="16" height="16" fill="white" transform="translate(8.5 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-navy.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-navy.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_472_1618)">
+<path d="M18.6569 21.3137L13 15.6569L18.6569 10" stroke="#30373F"/>
+</g>
+<rect x="0.5" y="0.5" width="31" height="31" rx="15.5" stroke="#30373F"/>
+<defs>
+<clipPath id="clip0_472_1618">
+<rect width="16" height="16" fill="white" transform="translate(8 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-white.svg
+++ b/packages/travelmakers-design-core/src/assets/svg/ic-arrow-previous-white.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_472_1594)">
+<path d="M19.1569 21.6569L13.5 16L19.1569 10.3432" stroke="white"/>
+</g>
+<rect x="0.5" y="0.5" width="31" height="31" rx="15.5" stroke="white"/>
+<defs>
+<clipPath id="clip0_472_1594">
+<rect width="16" height="16" fill="white" transform="translate(8 8)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.style.ts
+++ b/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.style.ts
@@ -1,0 +1,29 @@
+import { createStyles } from "@travelmakers-design/styles";
+interface ControlIndicatorStyles {
+  /** ControlIndicatorStyles 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
+}
+
+export default createStyles(
+  (theme, { size = "small" }: ControlIndicatorStyles) => {
+    return {
+      root: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      },
+
+      buttonContainer: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        width: size === "small" ? "56px" : "84px",
+      },
+      button: {
+        width: size === "small" ? "24px" : "32px",
+        height: size === "small" ? "24px" : "32px",
+        cursor: "pointer",
+      },
+    };
+  }
+);

--- a/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.tsx
@@ -12,6 +12,12 @@ import useStyles from "./ControlIndicator.style";
 
 export type ProgressStylesNames = ClassNames<typeof useStyles>;
 
+let SELECTED_PAGE = 1;
+
+// 현재 탭 반환 메소드
+export function getCurrentPage(): number {
+  return SELECTED_PAGE;
+}
 export interface ControlIndicatorProps
   extends TmComponentProps,
     React.ComponentPropsWithoutRef<"div"> {
@@ -67,7 +73,7 @@ export const ControlIndicator = forwardRef<
       { size },
       { overrideStyles, name: "ControlIndicator" }
     );
-    const [selectedPage, setSelectedPage] = useState(currentPage);
+    const [selectedPage, setSelectedPage] = useState(SELECTED_PAGE);
 
     let previousButton =
       color === "navy"
@@ -113,6 +119,7 @@ export const ControlIndicator = forwardRef<
       }
 
       setSelectedPage(page);
+      SELECTED_PAGE = page;
 
       previousClick();
     };
@@ -138,6 +145,8 @@ export const ControlIndicator = forwardRef<
         }
       }
       setSelectedPage(page);
+      SELECTED_PAGE = page;
+
       nextClick();
     };
 

--- a/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlIndicator/ControlIndicator.tsx
@@ -1,0 +1,177 @@
+import {
+  ClassNames,
+  TmComponentProps,
+  useTmTheme,
+} from "@travelmakers-design/styles";
+import React, { forwardRef, useState } from "react";
+import { Progress } from "../Progress";
+
+import { Image } from "../Image";
+import { View } from "../View";
+import useStyles from "./ControlIndicator.style";
+
+export type ProgressStylesNames = ClassNames<typeof useStyles>;
+
+export interface ControlIndicatorProps
+  extends TmComponentProps,
+    React.ComponentPropsWithoutRef<"div"> {
+  /** ControlIndicator 컴포넌트의 색상을 정합니다. */
+  color?: "navy" | "white";
+
+  /** ControlIndicator 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
+
+  /** ControlIndicator 컴포넌트의 토탈 page 수를 정합니다. */
+  totalPage?: number;
+
+  /** ControlIndicator 컴포넌트의 현재 page 를 정합니다. */
+  currentPage?: number;
+
+  /** ControlIndicator 컴포넌트의 현재 event transition 여부를 정합니다. */
+  activeBarTransition?: boolean;
+
+  /** ControlIndicator 컴포넌트의 무한루프 여부를 정합니다. */
+  infinity?: boolean;
+
+  /** ControlIndicator 컴포넌트의 이전 버튼을 눌렀을때 이벤트를 지정합니다. */
+  previousClick?: () => void;
+
+  /** ControlIndicator 컴포넌트의 다음 버튼을 눌렀을때 이벤트를 지정합니다. */
+  nextClick?: () => void;
+}
+
+export const ControlIndicator = forwardRef<
+  HTMLDivElement,
+  ControlIndicatorProps
+>(
+  (
+    {
+      color = "navy",
+      size = "small",
+      totalPage = 1,
+      currentPage = 1,
+      activeBarTransition = false,
+      infinity = false,
+      title,
+      className,
+      co,
+      previousClick,
+      nextClick,
+      overrideStyles,
+      ...props
+    },
+    ref
+  ) => {
+    const theme = useTmTheme();
+    const { classes, cx } = useStyles(
+      { size },
+      { overrideStyles, name: "ControlIndicator" }
+    );
+    const [selectedPage, setSelectedPage] = useState(currentPage);
+
+    let previousButton =
+      color === "navy"
+        ? require("../../assets/svg/ic-arrow-previous-navy.svg")
+        : require("../../assets/svg/ic-arrow-previous-white.svg");
+
+    let nextButton =
+      color === "navy"
+        ? require("../../assets/svg/ic-arrow-next-navy.svg")
+        : require("../../assets/svg/ic-arrow-next-white.svg");
+
+    // 무한 루프가 불가능한 경우, 버튼 이미지 수정
+    if (!infinity) {
+      if (selectedPage > totalPage || selectedPage <= 1) {
+        previousButton = require("../../assets/svg/ic-arrow-previous-disable.svg");
+      }
+
+      if (selectedPage >= totalPage) {
+        nextButton = require("../../assets/svg/ic-arrow-next-disable.svg");
+      }
+    }
+
+    const handlePreviousClick = () => {
+      let page = 1;
+      if (infinity) {
+        // 무한 루프 가능 할때,
+        if (selectedPage - 1 === 0) {
+          // 첫 번째 페이지 일 경우, 마지막 페이지로 이동
+          page = totalPage;
+        } else {
+          page = selectedPage - 1; // 첫 번째 페이지가 아닌 경우, 이전 페이지로 이동
+        }
+      } else {
+        // 무한 루프 불가능 할때,
+        if (selectedPage - 1 === 0) {
+          page = 1; // 첫 번째 페이지 일 경우, 1페이지 유지
+
+          // 버튼 disable 설정
+          previousButton = require("../../assets/svg/ic-arrow-previous-disable.svg");
+        } else {
+          page = selectedPage - 1; // 첫 번째 페이지가 아닌 경우, 이전 페이지로 이동
+        }
+      }
+
+      setSelectedPage(page);
+
+      previousClick();
+    };
+
+    const handleNextClick = () => {
+      let page = 1;
+      if (infinity) {
+        // 무한 루프 가능 할때,
+        if (selectedPage === totalPage) {
+          // 마지막 페이지 일 경우, 첫 번째 페이지로 이동
+          page = 1;
+        } else {
+          page = selectedPage + 1; // 마지막 페이지가 아닌 경우, 다음 페이지로 이동
+        }
+      } else {
+        // 무한 루프 불가능 할때,
+        if (selectedPage === totalPage) {
+          page = totalPage; // 마지막 페이지 일 경우, 마지막 페이지 유지
+
+          nextButton = require("../../assets/svg/ic-arrow-next-disable.svg");
+        } else {
+          page = selectedPage + 1; // 마지막 페이지가 아닌 경우, 다음 페이지로 이동
+        }
+      }
+      setSelectedPage(page);
+      nextClick();
+    };
+
+    return (
+      <View
+        ref={ref}
+        className={cx(classes.root, className)}
+        co={co}
+        {...props}
+      >
+        <Progress
+          color={color}
+          size={size}
+          totalPage={totalPage}
+          currentPage={selectedPage}
+          activeBarTransition={activeBarTransition}
+          indicator={true}
+        />
+        <div className={cx(classes.buttonContainer)}>
+          <Image
+            src={previousButton}
+            className={cx(classes.button)}
+            onClick={handlePreviousClick}
+          />
+          <Image
+            src={nextButton}
+            className={cx(classes.button)}
+            onClick={handleNextClick}
+          />
+        </div>
+      </View>
+    );
+  }
+);
+
+ControlIndicator.displayName =
+  "@travelmakers-design/core/Header/ControlIndicator";

--- a/packages/travelmakers-design-core/src/components/ControlIndicator/index.ts
+++ b/packages/travelmakers-design-core/src/components/ControlIndicator/index.ts
@@ -1,0 +1,2 @@
+export { ControlIndicator } from "./ControlIndicator";
+export type { ControlIndicatorProps } from "./ControlIndicator";

--- a/packages/travelmakers-design-core/src/components/ControlIndicator/stories/ControlIndicator.stories.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlIndicator/stories/ControlIndicator.stories.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { ControlIndicator } from "../ControlIndicator";
+
+export default {
+  title: "@travelmakers-design/core/Component/ControlIndicator",
+  component: ControlIndicator,
+  argTypes: {
+    color: {
+      defaultValue: "navy",
+      description: "ControlIndicator 컴포넌트의 색상을 정합니다.",
+      options: ["navy", "white"],
+      control: { type: "inline-radio" },
+    },
+    size: {
+      defaultValue: "small",
+      description: "ControlIndicator 컴포넌트의 색상을 정합니다.",
+      options: ["small", "large"],
+      control: { type: "inline-radio" },
+    },
+    totalPage: {
+      defaultValue: 1,
+      description: "ControlIndicator 컴포넌트의 토탈 page 수를 정합니다.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+      control: { type: "number" },
+    },
+    // [추가]: 컴포넌트 내에서 current page 를 관리해야 버튼 동작을 컨트롤 할 수 있어서 외부에서 current page를 입력 받는 것은 추후 조정 예정
+    // currentPage: {
+    //   defaultValue: 1,
+    //   description: "ControlIndicator 컴포넌트의 현재 page 수를 정합니다.",
+    //   table: {
+    //     type: {
+    //       summary: "number",
+    //     },
+    //   },
+    //   control: { type: "number" },
+    // },
+    activeBarTransition: {
+      defaultValue: false,
+      description:
+        "ControlIndicator 컴포넌트의 현재 event transition 여부를 정합니다.",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+      control: { type: "boolean" },
+    },
+    infinity: {
+      defaultValue: false,
+      description: "ControlIndicator 컴포넌트의 무한 루프 여부를 정합니다.",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+      control: { type: "boolean" },
+    },
+  },
+};
+
+export const Default = (props) => {
+  return (
+    <div style={{ padding: 24 }}>
+      <ControlIndicator {...props} />
+    </div>
+  );
+};

--- a/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.style.ts
+++ b/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.style.ts
@@ -1,0 +1,54 @@
+import { createStyles, TmTheme } from "@travelmakers-design/styles";
+
+interface ControlIndicatorStyles {
+  /** ControlIndicator 컴포넌트의 색상을 정합니다. */
+  color?: "navy" | "white";
+
+  /** ControlIndicator 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
+}
+
+const getFontStyles = (theme: TmTheme) => ({
+  small: {
+    fontFamily: "Pretendard",
+    fontWeight: "normal",
+    lineHeight: `${theme.lineHeights.b2}px`,
+    fontSize: theme.fontSizes.b2,
+    marginRight: "12px",
+    marginLeft: "12px",
+    width: "50px",
+  },
+
+  large: {
+    fontFamily: "Pretendard",
+    fontWeight: "normal",
+    lineHeight: `${theme.lineHeights.h5}px`,
+    fontSize: theme.fontSizes.h5,
+    marginRight: "20px",
+    marginLeft: "20px",
+    width: "70px",
+  },
+});
+
+export default createStyles(
+  (theme, { color = "navy", size = "small" }: ControlIndicatorStyles) => {
+    return {
+      root: {
+        display: "flex",
+        alignItems: "center",
+      },
+
+      indicator: {
+        ...getFontStyles(theme)[size],
+        color: color,
+        textAlign: "center",
+      },
+
+      button: {
+        width: "32px",
+        height: "32px",
+        cursor: "pointer",
+      },
+    };
+  }
+);

--- a/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.tsx
@@ -1,3 +1,4 @@
+import { CURRENT_SELECTION } from "@storybook/addon-docs";
 import {
   ClassNames,
   TmComponentProps,
@@ -11,6 +12,12 @@ import useStyles from "./ControlPagination.style";
 
 export type ProgressStylesNames = ClassNames<typeof useStyles>;
 
+let SELECTED_PAGE = 1;
+
+// 현재 탭 반환 메소드
+export function getCurrentPage(): number {
+  return SELECTED_PAGE;
+}
 export interface ControlPaginationProps
   extends TmComponentProps,
     React.ComponentPropsWithoutRef<"div"> {
@@ -61,7 +68,7 @@ export const ControlPagination = forwardRef<
       { color, size },
       { overrideStyles, name: "ControlPagination" }
     );
-    const [selectedPage, setSelectedPage] = useState(currentPage);
+    const [selectedPage, setSelectedPage] = useState(SELECTED_PAGE);
 
     let previousButton =
       color === "navy"
@@ -106,6 +113,7 @@ export const ControlPagination = forwardRef<
         }
       }
       setSelectedPage(page);
+      SELECTED_PAGE = page;
 
       previousClick();
     };
@@ -131,6 +139,8 @@ export const ControlPagination = forwardRef<
         }
       }
       setSelectedPage(page);
+      SELECTED_PAGE = page;
+
       nextClick();
     };
 

--- a/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlPagination/ControlPagination.tsx
@@ -1,0 +1,164 @@
+import {
+  ClassNames,
+  TmComponentProps,
+  useTmTheme,
+} from "@travelmakers-design/styles";
+import React, { forwardRef, useState } from "react";
+
+import { Image } from "../Image";
+import { View } from "../View";
+import useStyles from "./ControlPagination.style";
+
+export type ProgressStylesNames = ClassNames<typeof useStyles>;
+
+export interface ControlPaginationProps
+  extends TmComponentProps,
+    React.ComponentPropsWithoutRef<"div"> {
+  /** ControlPagination 컴포넌트의 색상을 정합니다. */
+  color?: "navy" | "white";
+
+  /** ControlPagination 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
+
+  /** ControlPagination 컴포넌트의 토탈 page 수를 정합니다. */
+  totalPage?: number;
+
+  /** ControlPagination 컴포넌트의 현재 page 를 정합니다. */
+  currentPage?: number;
+
+  /** ControlPagination 컴포넌트의 무한루프 여부를 정합니다. */
+  infinity?: boolean;
+
+  /** ControlPagination 컴포넌트의 이전 버튼을 눌렀을때 이벤트를 지정합니다. */
+  previousClick?: () => void;
+
+  /** ControlPagination 컴포넌트의 다음 버튼을 눌렀을때 이벤트를 지정합니다. */
+  nextClick?: () => void;
+}
+
+export const ControlPagination = forwardRef<
+  HTMLDivElement,
+  ControlPaginationProps
+>(
+  (
+    {
+      color = "navy",
+      size = "small",
+      totalPage = 1,
+      currentPage = 1,
+      infinity = false,
+      className,
+      co,
+      previousClick,
+      nextClick,
+      overrideStyles,
+      ...props
+    },
+    ref
+  ) => {
+    const theme = useTmTheme();
+    const { classes, cx } = useStyles(
+      { color, size },
+      { overrideStyles, name: "ControlPagination" }
+    );
+    const [selectedPage, setSelectedPage] = useState(currentPage);
+
+    let previousButton =
+      color === "navy"
+        ? require("../../assets/svg/ic-arrow-previous-navy.svg")
+        : require("../../assets/svg/ic-arrow-previous-white.svg");
+
+    let nextButton =
+      color === "navy"
+        ? require("../../assets/svg/ic-arrow-next-navy.svg")
+        : require("../../assets/svg/ic-arrow-next-white.svg");
+
+    // 무한 루프가 불가능한 경우, 버튼 이미지 수정
+    if (!infinity) {
+      if (selectedPage > totalPage || selectedPage <= 1) {
+        previousButton = require("../../assets/svg/ic-arrow-previous-disable.svg");
+      }
+
+      if (selectedPage >= totalPage) {
+        nextButton = require("../../assets/svg/ic-arrow-next-disable.svg");
+      }
+    }
+
+    const handlePreviousClick = () => {
+      let page = 1;
+      if (infinity) {
+        // 무한 루프 가능 할때,
+        if (selectedPage - 1 === 0) {
+          // 첫 번째 페이지 일 경우, 마지막 페이지로 이동
+          page = totalPage;
+        } else {
+          page = selectedPage - 1; // 첫 번째 페이지가 아닌 경우, 이전 페이지로 이동
+        }
+      } else {
+        // 무한 루프 불가능 할때,
+        if (selectedPage - 1 === 0) {
+          page = 1; // 첫 번째 페이지 일 경우, 1페이지 유지
+
+          // 버튼 disable 설정
+          previousButton = require("../../assets/svg/ic-arrow-previous-disable.svg");
+        } else {
+          page = selectedPage - 1; // 첫 번째 페이지가 아닌 경우, 이전 페이지로 이동
+        }
+      }
+      setSelectedPage(page);
+
+      previousClick();
+    };
+
+    const handleNextClick = () => {
+      let page = 1;
+      if (infinity) {
+        // 무한 루프 가능 할때,
+        if (selectedPage === totalPage) {
+          // 마지막 페이지 일 경우, 첫 번째 페이지로 이동
+          page = 1;
+        } else {
+          page = selectedPage + 1; // 마지막 페이지가 아닌 경우, 다음 페이지로 이동
+        }
+      } else {
+        // 무한 루프 불가능 할때,
+        if (selectedPage === totalPage) {
+          page = totalPage; // 마지막 페이지 일 경우, 마지막 페이지 유지
+
+          nextButton = require("../../assets/svg/ic-arrow-next-disable.svg");
+        } else {
+          page = selectedPage + 1; // 마지막 페이지가 아닌 경우, 다음 페이지로 이동
+        }
+      }
+      setSelectedPage(page);
+      nextClick();
+    };
+
+    return (
+      <View<any>
+        ref={ref}
+        className={cx(classes.root, className)}
+        co={co}
+        {...props}
+      >
+        <Image
+          src={previousButton}
+          className={cx(classes.button)}
+          onClick={handlePreviousClick}
+        />
+
+        <span className={cx(classes.indicator)}>
+          {selectedPage} / {totalPage}
+        </span>
+        <Image
+          src={nextButton}
+          className={cx(classes.button)}
+          onClick={handleNextClick}
+        />
+      </View>
+    );
+  }
+);
+
+ControlPagination.displayName =
+  "@travelmakers-design/core/Header/ControlPagination";

--- a/packages/travelmakers-design-core/src/components/ControlPagination/index.ts
+++ b/packages/travelmakers-design-core/src/components/ControlPagination/index.ts
@@ -1,0 +1,2 @@
+export { ControlPagination } from "./ControlPagination";
+export type { ControlPaginationProps } from "./ControlPagination";

--- a/packages/travelmakers-design-core/src/components/ControlPagination/stories/ControlPagination.stories.tsx
+++ b/packages/travelmakers-design-core/src/components/ControlPagination/stories/ControlPagination.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import { ControlPagination } from "../ControlPagination";
+
+export default {
+  title: "@travelmakers-design/core/Component/ControlPagination",
+  component: ControlPagination,
+  argTypes: {
+    color: {
+      defaultValue: "navy",
+      description: "ControlPagination 컴포넌트의 색상을 정합니다.",
+      options: ["navy", "white"],
+      control: { type: "inline-radio" },
+    },
+    size: {
+      defaultValue: "small",
+      description: "ControlPagination 컴포넌트의 색상을 정합니다.",
+      options: ["small", "large"],
+      control: { type: "inline-radio" },
+    },
+    infinity: {
+      defaultValue: false,
+      description: "ControlPagination 컴포넌트의 무한 루프 여부를 정합니다.",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+      control: { type: "boolean" },
+    },
+    totalPage: {
+      defaultValue: 1,
+      description: "ControlPagination 컴포넌트의 토탈 page 수를 정합니다.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+      control: { type: "number" },
+    },
+    // [추가]: 컴포넌트 내에서 current page 를 관리해야 버튼 동작을 컨트롤 할 수 있어서 외부에서 current page를 입력 받는 것은 추후 조정 예정
+    // currentPage: {
+    //   defaultValue: 1,
+    //   description: "ControlPagination 컴포넌트의 현재 page 수를 정합니다.",
+    //   table: {
+    //     type: {
+    //       summary: "number",
+    //     },
+    //   },
+    //   control: { type: "number" },
+    // },
+  },
+};
+
+export const Default = (props) => {
+  return (
+    <div style={{ padding: 24 }}>
+      <ControlPagination {...props} />
+    </div>
+  );
+};

--- a/packages/travelmakers-design-core/src/components/Indicator/Indicator.style.ts
+++ b/packages/travelmakers-design-core/src/components/Indicator/Indicator.style.ts
@@ -13,10 +13,30 @@ interface IndicatorStyles {
 
   /** Indicator 컴포넌트의 색상을 정합니다. */
   color?: "navy" | "white";
+
+  /** Indicator 컴포넌트의 크기를 정합니다. */
+  size?: "small" | "large";
 }
 
+const getFontStyles = (theme: TmTheme) => ({
+  small: {
+    fontFamily: "PT Serif",
+    fontSize: theme.fontSizes.b3,
+    lineHeight: `${theme.lineHeights.b3}px`,
+  },
+
+  large: {
+    fontFamily: "PT Serif",
+    fontSize: theme.fontSizes.h5,
+    lineHeight: `${theme.lineHeights.h5}px`,
+  },
+});
+
 export default createStyles(
-  (theme, { type = "text", color = "navy" }: IndicatorStyles) => {
+  (
+    theme,
+    { type = "text", color = "navy", size = "large" }: IndicatorStyles
+  ) => {
     return {
       root: {
         display: "flex",
@@ -24,9 +44,8 @@ export default createStyles(
       },
 
       indicator: {
+        ...getFontStyles(theme)[size],
         fontFamily: "PT Serif",
-        fontSize: theme.fontSizes.h5,
-        lineHeight: `${theme.lineHeights.h5}px`,
         fontWeight: "700",
         color: color === "white" ? "white" : theme.colors.navy1,
         letterSpacing: "2.66667px",

--- a/packages/travelmakers-design-core/src/components/Indicator/Indicator.tsx
+++ b/packages/travelmakers-design-core/src/components/Indicator/Indicator.tsx
@@ -22,6 +22,9 @@ export interface IndicatorProps
   /** Indicator 컴포넌트의 색상을 정합니다. */
   color?: "navy" | "white";
 
+  /** Indicator 컴포넌트의 크기를 정합니다. */
+  size?: "small" | "large";
+
   /** Indicator 컴포넌트의 토탈 page 수를 정합니다. */
   totalPage?: number;
 
@@ -34,6 +37,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
     {
       type = "text",
       color = "navy",
+      size = "large",
       totalPage = 1,
       currentPage = 1,
       className,
@@ -45,7 +49,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
   ) => {
     const theme = useTmTheme();
     const { classes, cx } = useStyles(
-      { type, color },
+      { type, color, size },
       { overrideStyles, name: "Indicator" }
     );
 

--- a/packages/travelmakers-design-core/src/components/Progress/Progress.style.ts
+++ b/packages/travelmakers-design-core/src/components/Progress/Progress.style.ts
@@ -11,6 +11,9 @@ interface ProgressStyles {
   /** Progress 컴포넌트의 색상을 정합니다. */
   color?: "navy" | "white";
 
+  /** Progress 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
+
   /** Progress 컴포넌트의 indicator 표시 여부를 정합니다. */
   indicator?: boolean;
 }
@@ -33,7 +36,10 @@ const getFontStyles = (theme: TmTheme) => ({
   },
 });
 export default createStyles(
-  (theme, { color = "navy", indicator = false }: ProgressStyles) => {
+  (
+    theme,
+    { color = "navy", indicator = false, size = "large" }: ProgressStyles
+  ) => {
     return {
       root: {
         display: "flex",
@@ -48,7 +54,7 @@ export default createStyles(
         display: "block",
         position: "relative",
         width: "30vw",
-        maxWidth: "456px",
+        maxWidth: size === "small" ? "171px" : "456px",
         height: "2px",
         borderRadius: "3px",
         backgroundColor:

--- a/packages/travelmakers-design-core/src/components/Progress/Progress.tsx
+++ b/packages/travelmakers-design-core/src/components/Progress/Progress.tsx
@@ -6,7 +6,7 @@ import {
   TmSize,
   useTmTheme,
 } from "@travelmakers-design/styles";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useState } from "react";
 import { Indicator } from "../Indicator";
 
 import { View } from "../View";
@@ -19,6 +19,9 @@ export interface ProgressProps
     React.ComponentPropsWithoutRef<"div"> {
   /** Progress 컴포넌트의 색상을 정합니다. */
   color?: "navy" | "white";
+
+  /** Progress 컴포넌트의 색상을 정합니다. */
+  size?: "small" | "large";
 
   /** Progress 컴포넌트의 indicator 표시 여부를 정합니다. */
   indicator?: boolean;
@@ -38,6 +41,7 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
     {
       color = "navy",
       indicator = false,
+      size = "large",
       totalPage = 1,
       currentPage = 1,
       activeBarTransition = false,
@@ -51,7 +55,7 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
   ) => {
     const theme = useTmTheme();
     const { classes, cx } = useStyles(
-      { color, indicator },
+      { color, indicator, size },
       { overrideStyles, name: "Progress" }
     );
 
@@ -67,6 +71,7 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
             currentPage={currentPage}
             totalPage={totalPage}
             color={color}
+            size={size}
             className={cx(classes.indicator)}
           />
         )}


### PR DESCRIPTION
## 목적
Control Indicator, Pagination 디자인 시스템 추가

## 수정한 내용
- Control Indicator 추가
- Control Pagination 추가
- Indicator Component size props 추가 및 적용 (default: "large")
- Progress Component size props 추가 및 적용 (default: "large")

## TODO / 고민 중인 내용
- component 내에서 current page 를 관리해야 버튼 동작을 컨트롤 할 수 있어서 외부에서 current page를 입력 받는 것은 추후 조정 하면 좋을 것 같습니다! ( + Progress 는 현재 current page를 외부에서 입력받습니다. 그러나 Control Indicator에서 이전 페이지로 이동할때, Progress 의 activeBarTransition 애니메이션을 생략하기 위해서는 current page를 component 내부에서 관리해야 해서 방법을 논의해보면 좋을 것 같습니다!)
